### PR TITLE
Replace addJsFile with addHeaderData

### DIFF
--- a/Classes/ViewHelpers/AssetViewHelper.php
+++ b/Classes/ViewHelpers/AssetViewHelper.php
@@ -66,8 +66,8 @@ class AssetViewHelper extends AbstractViewHelper
         $pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);
 
         if ($viteDevServerRunning) {
-            $pageRenderer->addJsFile($domainWithPort . '/@vite/client', 'module');
-            $pageRenderer->addJsFile($domainWithPort . '/' . $srcPath . '/' . $entry, 'module');
+            $pageRenderer->addHeaderData('<script src="' . $domainWithPort . '/@vite/client' . '" type="module"></script>');
+            $pageRenderer->addHeaderData('<script src="' . $domainWithPort . '/' . $srcPath . '/' . $entry . '" type="module"></script>');
         }
 
         if (!$viteDevServerRunning and $outPath and $srcPath) {


### PR DESCRIPTION
Replace addJsFile with addHeaderData, because with addJsFile the script tags are not added to the DOM. Maybe there was a change from v12 to v13, where the addJsFile function only includes files, where the paths can be resolved?